### PR TITLE
Use Instants and Tokio Intervals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 zmq = "0.9.0"
 tokio = "0.1.14"
+lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2018"
 
 [dependencies]
 zmq = "0.9.0"
+tokio = "0.1.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,8 @@
+extern crate tokio;
+
+use tokio::prelude::*;
+use tokio::timer::Interval;
+
 use std::cmp::min;
 use std::collections::VecDeque;
 use std::env;
@@ -5,13 +10,13 @@ use std::io::{self, Write};
 use std::process;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::{Duration, SystemTime};
+use std::time::{Duration, Instant};
 
-const VERSION: &'static str = "v0.1.0";
-const NAME: &'static str = "ictmon";
-const ADDRESS: &'static str = "localhost";
+const VERSION: &str = "v0.1.0";
+const NAME: &str = "ictmon";
+const ADDRESS: &str = "localhost";
 const PORT: u16 = 5560;
-const CHANNEL_TX: &'static str = "tx";
+const CHANNEL_TX: &str = "tx";
 const MOVING_AVG_INTERVAL_MS: u64 = 60000;
 const INITIAL_SLEEP_MS: u64 = 1000;
 const UPDATE_INTERVAL_MS: u64 = 1000;
@@ -23,21 +28,19 @@ struct Arguments {
 
 impl Arguments {
     pub fn new(args: Vec<String>) -> Result<Self, String> {
-        if args.len() == 1 {
-            Ok(Arguments {
+        match args.len() {
+            1 => Ok(Arguments {
                 address: ADDRESS.to_string(),
                 port: PORT,
-            })
-        } else if args.len() == 3 {
-            Ok(Arguments {
+            }),
+            3 => Ok(Arguments {
                 address: args[1].clone(),
                 port: args[2].parse::<u16>().unwrap(),
-            })
-        } else {
-            Err(format!(
+            }),
+            _ => Err(format!(
                 "Wrong number of arguments provided. Usage: ./{} <IP> <ZMQ-Port>",
                 NAME
-            ))
+            )),
         }
     }
 }
@@ -58,10 +61,12 @@ fn main() {
     let subscriber = context.socket(zmq::SUB).unwrap();
     let address = format!("tcp://{}:{}", args.address, args.port);
 
-    subscriber.connect(&address).expect(&format!(
-        "Could not connect to publisher: '{}:{}'.",
-        args.address, args.port
-    ));
+    subscriber.connect(&address).unwrap_or_else(|_| {
+        panic!(
+            "Could not connect to publisher: '{}:{}'.",
+            args.address, args.port
+        )
+    });
 
     println!(
         "Info: Subscribed to Ict node running ZeroMQ IXI extension module at '{}:{}'.",
@@ -73,16 +78,14 @@ fn main() {
     let subscription = CHANNEL_TX.to_string().into_bytes();
     subscriber.set_subscribe(&subscription).unwrap();
 
-    let arrival_timestamps: Arc<Mutex<VecDeque<Duration>>> = Arc::new(Mutex::new(VecDeque::new()));
+    let arrival_timestamps: Arc<Mutex<VecDeque<Instant>>> = Arc::new(Mutex::new(VecDeque::new()));
     let arrival_timestamps_recv = Arc::clone(&arrival_timestamps);
 
     thread::spawn(move || {
-        let mut arrival_timestamp: Duration;
+        let mut arrival_timestamp: Instant;
         loop {
             subscriber.recv_msg(0).unwrap();
-            arrival_timestamp = SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap();
+            arrival_timestamp = Instant::now();
 
             let mut queue = arrival_timestamps_recv.lock().unwrap();
             queue.push_back(arrival_timestamp);
@@ -90,40 +93,35 @@ fn main() {
     });
 
     let interval = Duration::from_millis(MOVING_AVG_INTERVAL_MS);
-    let mut window_start: Duration;
-    let mut now: Duration;
-    let mut uptime_ms: u64;
 
-    let init = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap();
+    let mut uptime_ms: u64 = 0;
+    let init = Instant::now();
 
     thread::sleep(Duration::from_millis(INITIAL_SLEEP_MS));
 
-    loop {
-        now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .unwrap();
-
-        window_start = now - interval;
-        {
-            let mut queue = arrival_timestamps.lock().unwrap();
-            while queue.len() > 0 && queue.front().unwrap() < &window_start {
-                queue.pop_front();
+    let task = Interval::new_interval(Duration::from_millis(UPDATE_INTERVAL_MS))
+        .for_each(move |instant| {
+            let window_start = instant - interval;
+            {
+                let mut queue = arrival_timestamps.lock().unwrap();
+                while queue.len() > 0 && queue.front().unwrap() < &window_start {
+                    queue.pop_front();
+                }
+                uptime_ms = (instant - init).as_secs() * 1000 + u64::from((instant - init).subsec_millis());
+                print_tps(
+                    queue.len() as f64 / (min(MOVING_AVG_INTERVAL_MS, uptime_ms) as f64 / 1000_f64),
+                );
             }
-            uptime_ms = (now - init).as_secs() * 1000 + (now - init).subsec_millis() as u64;
-            print_tps(
-                queue.len() as f64 / (min(MOVING_AVG_INTERVAL_MS, uptime_ms) as f64 / 1000_f64),
-            );
-        }
-        thread::sleep(Duration::from_millis(UPDATE_INTERVAL_MS));
-    }
+            Ok(())
+        })
+        .map_err(|e| panic!("interval errored; err={:?}", e));
+    tokio::run(task);
+}
 
-    fn print_tps(tps: f64) {
-        print!(
-            "\r\x1b[2A+--------------+\n|{:>10.2} tps|\n+--------------+",
-            tps
-        );
-        io::stdout().flush().unwrap();
-    }
+fn print_tps(tps: f64) {
+    print!(
+        "\r\x1b[2A+--------------+\n|{:>10.2} tps|\n+--------------+",
+        tps
+    );
+    io::stdout().flush().unwrap();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
-extern crate tokio;
-
 use tokio::prelude::*;
 use tokio::timer::Interval;
+use lazy_static::lazy_static;
 
 use std::cmp::min;
 use std::collections::VecDeque;
@@ -14,12 +13,15 @@ use std::time::{Duration, Instant};
 
 const VERSION: &str = "v0.1.0";
 const NAME: &str = "ictmon";
-const ADDRESS: &str = "localhost";
 const PORT: u16 = 5560;
-const CHANNEL_TX: &str = "tx";
 const MOVING_AVG_INTERVAL_MS: u64 = 60000;
 const INITIAL_SLEEP_MS: u64 = 1000;
 const UPDATE_INTERVAL_MS: u64 = 1000;
+
+lazy_static! {
+    static ref ADDRESS: String = String::from("localhost");
+    static ref CHANNEL_TX: String = String::from("tx");
+}
 
 struct Arguments {
     address: String,
@@ -30,7 +32,7 @@ impl Arguments {
     pub fn new(args: Vec<String>) -> Result<Self, String> {
         match args.len() {
             1 => Ok(Arguments {
-                address: ADDRESS.to_string(),
+                address: ADDRESS.clone(),
                 port: PORT,
             }),
             3 => Ok(Arguments {
@@ -46,14 +48,13 @@ impl Arguments {
 }
 
 fn main() {
-    let args: Arguments;
-    match Arguments::new(env::args().collect::<Vec<String>>()) {
-        Ok(a) => args = a,
+    let args: Arguments = match Arguments::new(env::args().collect::<Vec<String>>()) {
+        Ok(a) => a,
         Err(s) => {
             println!("{}", s);
             process::exit(0);
         }
-    }
+    };
 
     println!("Welcome to '{}' (Ict Network Monitor) {}", NAME, VERSION);
 
@@ -75,7 +76,7 @@ fn main() {
 
     println!("\n");
 
-    let subscription = CHANNEL_TX.to_string().into_bytes();
+    let subscription = CHANNEL_TX.as_bytes();
     subscriber.set_subscribe(&subscription).unwrap();
 
     let arrival_timestamps: Arc<Mutex<VecDeque<Instant>>> = Arc::new(Mutex::new(VecDeque::new()));


### PR DESCRIPTION
- `const &str` is static already
- Instead of doing durations since epoch, higher accuracy using instants.
- If you're going to do an interval while trying to track time, sleeping threads aren't a good idea. Tokio task should be better.

NOTE: Haven't tested any of this because I didn't feel like setting up iri and such. 